### PR TITLE
Allow the code to work with python 2 and 3

### DIFF
--- a/IONEX/teccalc.py
+++ b/IONEX/teccalc.py
@@ -75,7 +75,7 @@ def calcTEC(coordLat,coordLon,filename):
 	pointsLat = ((endLat - startLat)/stepLat) + 1
 
 	# 3D array that will contain TEC values only
-	a = numpy.zeros((NumberOfMaps,pointsLat,pointsLon))
+	a = numpy.zeros((int(NumberOfMaps), int(pointsLat), int(pointsLon)))
 
 	# Selecting only the TEC values to store in the 3-D array
 	counterMaps = 1
@@ -142,7 +142,7 @@ def calcTEC(coordLat,coordLon,filename):
 	# one indicated in the IONEX manual
 
 	# creating a new array that will contain 25 maps in total 
-	newa = numpy.zeros((totalmaps,pointsLat,pointsLon))
+	newa = numpy.zeros((totalmaps, int(pointsLat), int(pointsLon)))
 	inc = 0
 	for item in range(int(NumberOfMaps)):
 		newa[inc,:,:] = a[item,:,:]

--- a/IONEX/tecrmscalc.py
+++ b/IONEX/tecrmscalc.py
@@ -63,7 +63,7 @@ def calcRMSTEC(coordLat,coordLon,filename):
 	pointsLat = ((endLat - startLat)/stepLat) + 1
 
 	# 3D array that will contain RMS TEC values only
-	a = numpy.zeros((NumberOfMaps,pointsLat,pointsLon)) # (Z,Y,X)
+	a = numpy.zeros((int(NumberOfMaps), int(pointsLat), int(pointsLon))) # (Z,Y,X)
 
 	# selecting only the RMS TEC values to store in the 3-D array
 	counterMaps = 1
@@ -130,7 +130,7 @@ def calcRMSTEC(coordLat,coordLon,filename):
 	# one indicated in the IONEX manual
 
 	# Creating a new array that will contain 25 maps in total 
-	newa = numpy.zeros((totalmaps,pointsLat,pointsLon))
+	newa = numpy.zeros((totalmaps, int(pointsLat), int(pointsLon)))
 	inc = 0
 	for item in range(int(NumberOfMaps)):
 		newa[inc,:,:] = a[item,:,:]

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Users are encouraged to report bugs or flaws. Suggestions or comments that the u
 You will need the following modules from python intalled in your machine:
 - numpy
 - scipy
+- future
 You also need the gcc compiler
 
 The following are a few steps to get this code working:

--- a/SiderealPackage/rdalaz.py
+++ b/SiderealPackage/rdalaz.py
@@ -9,6 +9,8 @@
 #================================================================
 # Imports
 #----------------------------------------------------------------
+from __future__ import print_function
+
 import sys, re
 import sidereal
 from math import *
@@ -122,7 +124,7 @@ def checkArgs(ti):
         usage ("Incorrect command line argument count." )
     else:
         rawRADec, rawLat, rawLon, rawDT, fileIONEXTEC  =  argList
-	rawDT = str(ti)
+        rawDT = str(ti)
 	
     #-- 2 --
     # [ if rawRADec is a valid set of equatorial coordinates ->
@@ -140,7 +142,7 @@ def checkArgs(ti):
     #     stop execution ]
     try:
         lat  =  sidereal.parseLat ( rawLat )
-    except SyntaxError, detail:
+    except SyntaxError as detail:
         usage ( "Invalid latitude: %s" % detail )
 
     #-- 4 --
@@ -151,7 +153,7 @@ def checkArgs(ti):
     #     stop execution ]
     try:
         lon  =  sidereal.parseLon ( rawLon )
-    except SyntaxError, detail:
+    except SyntaxError as detail:
         usage ( "Invalid longitude: %s" % detail )
 
     #-- 5 --
@@ -162,7 +164,7 @@ def checkArgs(ti):
     #     stop execution ]
     try:
         dt  =  sidereal.parseDatetime ( rawDT )
-    except SyntaxError, detail:
+    except SyntaxError as detail:
         usage ( "Invalid timestamp: %s" % detail )
 
     #-- 6 --
@@ -178,11 +180,11 @@ def usage ( *L ):
                            concatenated)
           stop execution ]
     """
-    print >>sys.stderr, "*** Usage:"
-    print >>sys.stderr, "***   rdaa RA+dec lat lon datetime"
-    print >>sys.stderr, "*** Or:"
-    print >>sys.stderr, "***   rdaa RA-dec lat lon datetime"
-    print >>sys.stderr, "*** Error: %s" % "".join(L)
+    print("*** Usage:", file=sys.stderr)
+    print("***   rdaa RA+dec lat lon datetime", file=sys.stderr)
+    print("*** Or:", file=sys.stderr)
+    print("***   rdaa RA-dec lat lon datetime", file=sys.stderr)
+    print("*** Error: %s" % "".join(L), file=sys.stderr)
     raise SystemExit
 # - - -   c h e c k R A D e c
 
@@ -223,7 +225,7 @@ def checkRADec ( rawRADec ):
     try:
         raHours  =  sidereal.parseHours ( rawRA )
         ra  =  sidereal.hoursToRadians ( raHours )
-    except SyntaxError, detail:
+    except SyntaxError as detail:
         usage ( "Right ascension '%s' should have the form "
                 "'NNh[NNm[NN.NNNs]]'." % rawRA )
     #-- 4 --
@@ -233,7 +235,7 @@ def checkRADec ( rawRADec ):
     #     stop execution ]
     try:
         absDec  =  sidereal.parseAngle ( rawDec )
-    except SyntaxError, detail:
+    except SyntaxError as detail:
         usage ( "Right ascension '%s' should have the form "
                 "'NNd[NNm[NN.NNNs]]'." % rawDec )
     #-- 5 --

--- a/SiderealPackage/sidereal.py
+++ b/SiderealPackage/sidereal.py
@@ -194,8 +194,8 @@ def parseDate ( s ):
     #   else -> raise SyntaxError ]
     m  =  DATE_PAT.match ( s )
     if  m is None:
-        raise SyntaxError, ( "Date does not have pattern YYYY-DD-MM: "
-                             "'%s'" % s )
+        raise SyntaxError ( "Date does not have pattern YYYY-DD-MM: "
+                            "'%s'" % s )
     #-- 2 --
     year   =  int ( m.group ( YEAR_FIELD ) )
     month  =  int ( m.group ( MONTH_FIELD ) )
@@ -232,8 +232,8 @@ def parseTime ( s ):
     if  minuteTail.startswith(':'):
         m  =  FLOAT_PAT.match ( minuteTail[1:] )
         if  m is None:
-            raise SyntaxError, ( "Expecting minutes: '%s'" %
-                                 minuteTail )
+            raise SyntaxError ( "Expecting minutes: '%s'" %
+                                minuteTail )
         else:
             decMinute  =  float(m.group())
             secondTail  =  minuteTail[m.end()+1:]
@@ -253,8 +253,8 @@ def parseTime ( s ):
     if  secondTail.startswith(':'):
         m  =  FLOAT_PAT.match ( secondTail[1:] )
         if  m is None:
-            raise SyntaxError, ( "Expecting seconds: '%s'" %
-                                 secondTail )
+            raise SyntaxError ( "Expecting seconds: '%s'" %
+                                secondTail )
         else:
             decSecond  =  float(m.group())
             zoneTail  =  secondTail[m.end()+1:]
@@ -312,7 +312,7 @@ def parseZone ( s ):
         tz  =  zoneCodeMap[s.upper()]
         return tz
     except KeyError:
-        raise SyntaxError, ( "Unknown time zone code: '%s'" % s )
+        raise SyntaxError ( "Unknown time zone code: '%s'" % s )
 # - - -   p a r s e F i x e d Z o n e
 
 HHMM_PAT  =  re.compile (
@@ -332,8 +332,8 @@ def parseFixedZone ( s ):
     if  s.startswith('+'):    sign  =  1
     elif  s.startswith('-'):  sign  =  -1
     else:
-        raise SyntaxError, ( "Expecting zone modifier as %shhmm: "
-                             "'%s'" % (s[0], s) )
+        raise SyntaxError ( "Expecting zone modifier as %shhmm: "
+                            "'%s'" % (s[0], s) )
     #-- 2 --
     # [ if s[1:] matches HHMM_PAT ->
     #     hours  :=  the HH part as an int
@@ -342,8 +342,8 @@ def parseFixedZone ( s ):
     rawHHMM  =  s[1:]
     m  =  HHMM_PAT.match ( rawHHMM )
     if  m is None:
-        raise SyntaxError, ( "Expecting zone modifier as %sHHMM: "
-                             "'%s'" % (s[0], s) )
+        raise SyntaxError ( "Expecting zone modifier as %sHHMM: "
+                            "'%s'" % (s[0], s) )
     else:
         hours  =  int ( rawHHMM[:2] )
         minutes  =  int ( rawHHMM[2:] )
@@ -541,8 +541,8 @@ def parseAngle ( s ):
             second, checkTail  =  parseFloatSuffix ( secTail,
                 S_PAT, "Seconds followed by 's'" )
             if  len(checkTail) != 0:
-                raise SyntaxError, ( "Unidentifiable angle parts: "
-                                     "'%s'" % checkTail )
+                raise SyntaxError ( "Unidentifiable angle parts: "
+                                    "'%s'" % checkTail )
     #-- 4 --
     # [ return the angle (degree, minute, second) in radians ]
     angleDegrees  =  dmsUnits.mixToSingle ( (degree, minute, second) )
@@ -617,7 +617,7 @@ def parseRe ( s, regex, message ):
     #   else -> raise SyntaxError, "Expecting (message)" ]
     m  =  regex.match ( s )
     if  m is None:
-        raise SyntaxError, "Expecting %s: '%s'" % (message, s)
+        raise SyntaxError ("Expecting %s: '%s'" % (message, s))
     #-- 2 --
     # [ return (matched text from s, text from s after match) ]
     head  =  m.group()
@@ -645,8 +645,8 @@ def parseLat ( s ):
     #   else -> raise SyntaxError ]
     m  =  NS_PAT.match ( last )
     if  m is None:
-        raise SyntaxError, ( "Latitude '%s' does not end with 'n' "
-                             "or 's'." % s )
+        raise SyntaxError ( "Latitude '%s' does not end with 'n' "
+                            "or 's'." % s )
     else:
         nsFlag  =  last.lower()
     #-- 3 --
@@ -682,8 +682,8 @@ def parseLon ( s ):
     #   else -> raise SyntaxError ]
     m  =  EW_PAT.match ( last )
     if  m is None:
-        raise SyntaxError, ( "Longitude '%s' does not end with "
-                             "'e' or 'w'." % s )
+        raise SyntaxError ( "Longitude '%s' does not end with "
+                            "'e' or 'w'." % s )
     else:
         ewFlag  =  last.lower()
     #-- 3 --
@@ -746,8 +746,8 @@ def parseHours ( s ):
             second, checkTail  =  parseFloatSuffix ( secTail,
                 S_PAT, "Seconds followed by 's'" )
             if  len(checkTail) != 0:
-                raise SyntaxError, ( "Unidentifiable angle parts: "
-                                     "'%s'" % checkTail )
+                raise SyntaxError ( "Unidentifiable angle parts: "
+                                    "'%s'" % checkTail )
     #-- 4 --
     # [ return the quantity (hour, minute, second) in hours ]
     result  =  dmsUnits.mixToSingle ( (hour, minute, second) )
@@ -824,7 +824,7 @@ class MixedUnits:
         #   else ->
         #     result  :=  result + (a list of shortage zeroes) ]
         if  shortage < 0:
-            raise ValueError, ( "Value %s has too many elements; "
+            raise ValueError ( "Value %s has too many elements; "
                 "max is %d." % (coeffs, stdLen) )
         elif  shortage > 0:
             result  +=  [0.0] * shortage

--- a/ionFRM.py
+++ b/ionFRM.py
@@ -30,15 +30,20 @@ path='/Users/sob017/Python/ionFR/ionFR-master/'
 
 import sys
 import os
+
+import math
+from scipy import pi
+
+# Add ionFR modules to the PYTHONPATH (internally, this is sys.path).
 sys.path.append(""+str(path)+"SiderealPackage")
 sys.path.append(""+str(path)+"PunctureIonosphereCoord")
 sys.path.append(""+str(path)+"IONEX")
 import rdalaz
+from rdalaz import usage
 import ippcoor_v1 as ippcoor
 import teccalc
 import tecrmscalc
 import ionheight
-from scipy import *
 
 # Defining some variables for further use
 TECU = pow(10,16)
@@ -99,7 +104,7 @@ for h in range(24):
 		TECpath = VTEC*TEC2m2/math.cos(ZenPunct) # from vertical TEC to line of sight TEC
 
 		# Calculation of RMS TEC path value (same as the step above)
- 		if rawLatitude[-1] == 's':
+		if rawLatitude[-1] == 's':
 			if rawLongitude[-1] == 'e':
 				RMSTECarr = tecrmscalc.calcRMSTEC(-(LatO + offLat)*180.0/pi,(LonO + offLon)*180.0/pi,nameIONEX)
 			if rawLongitude[-1] == 'w':
@@ -125,7 +130,7 @@ for h in range(24):
 			if rawLongitude[-1] == 'w':
 				f.write(''+str(year)+','+str(month)+','+str(day)+' C K'+str((EarthRadius+AltIon)/1000.0)+' '+str((LatO + offLat)*180.0/pi)+' '+str(-(LonO + offLon)*180.0/pi)+'')
 		f.close()
-		os.system(''+str(path)+'IGRF/geomag70_linux/geomag70.exe '+str(path)+'ionFR_2018/IGRF/geomag70_linux/IGRF12.COF f '+str(path)+'ionFR_2018/IGRF/geomag70_linux/input.txt '+str(path)+'ionFR_2018/IGRF/geomag70_linux/output.txt')
+		os.system(''+str(path)+'IGRF/geomag70_linux/geomag70.exe '+str(path)+'IGRF/geomag70_linux/IGRF12.COF f '+str(path)+'IGRF/geomag70_linux/input.txt '+str(path)+'IGRF/geomag70_linux/output.txt')
 		g = open(''+str(path)+'IGRF/geomag70_linux/output.txt', 'r')
 		data = g.readlines()
 		g.close()

--- a/ionFRM.py
+++ b/ionFRM.py
@@ -24,13 +24,14 @@
 # obtain 24 RM values (from 00~23)
 #-----------------------------------------------------------
 
-path='/Users/sob017/Python/ionFR/ionFR-master/'
+# `path` is the variable describing where the ionFR code is. Determine this
+# automatically.
+import os
+path = os.path.dirname(os.path.realpath(__file__)) + "/"
 
 #-----------------------------------------------------------
 
 import sys
-import os
-
 import math
 from scipy import pi
 


### PR DESCRIPTION
There are three important changes here:

1. The future module is now needed (this could be relaxed if we didn't want a usage string to be printed to `stderr`);
2. The path variable defined in `ionFRM.py` is now determined automatically.  This may or may not be useful, but that's what pull requests are for.
3. I had to remove "ionFR_2018" from a path in `ionFRM.py` to get the example to work (see the last diff shown in this PR).  I assume that was not meant to be there.

With these changes, I get the same output (modulo floating-point-precision errors) in both python 2 and 3.

I also assume that the `usage` function used in `ionFRM.py` wants to use `usage` from `rdalaz.py`.  Before these commits, no other `usage` function was available to `ionFRM.py`.